### PR TITLE
alternate annotation check for denotate function

### DIFF
--- a/cmds.pl
+++ b/cmds.pl
@@ -60,7 +60,7 @@ sub task_den_or_del {
   for my $t (0 .. $#{ $report_tokens[$task_selected_idx] } ) {
     $str .= "$report_tokens[$task_selected_idx][$t]";
   }
-  my $target = ( $str !~ s/^\s*\d+\/\d+\/\d+\s+// )
+  my $target = ( $str !~ s/^\s*\d+\/\d+\/\d+\s+// and $str !~ s/^\s*\d+-\d+-\d+\s+// )
              ? "task"
              : "annotation";
   $str =~ s/\s+$//;


### PR DESCRIPTION
maybe it was a problem with my locale, but annotations get saved with leading YYYY-MM-DD date that was not detected by original regexp, leading `D` command in vit to delete entire task even if i was highlighting annotations.

in my case this fixes the issue
